### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A gem to scrape craiglist data , use at own risk.  
 
-####Warning
+#### Warning
 
 This gem does not work if hosted on heroku or ec2 , it appears [craiglist blocks requests coming from them.](http://stackoverflow.com/questions/14328955/http-get-on-craigslist-blocked)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
